### PR TITLE
Allow admins to use recreate form to submit results

### DIFF
--- a/pages/recreateform/index.tsx
+++ b/pages/recreateform/index.tsx
@@ -126,7 +126,7 @@ const RecreateFormContainer = ({ role }: SubmitFormProps) => {
   const validated = () => {
     let submit = true;
     Object.keys(form).forEach((key: string) => {
-      if (key !== "video1" && form[key as keyof RecreateFormState].value === "") {
+      if (key !== "video1" && key !== "oldId" && form[key as keyof RecreateFormState].value === "") {
         setForm((prevState: any) => ({
           ...prevState,
           [key]: {


### PR DESCRIPTION
The recreate form has been adapted to allow admins to submit any result. In order to do it, leave the old id field blank

The functionality was almost finished.